### PR TITLE
Fix links for documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,8 +48,7 @@ defmodule PreCommitHook.Mixfile do
       licenses: ["MIT"],
       maintainers: ["tyr.chen@gmail.com"],
       links: %{
-        "GitHub" => "https://github.com/tyrchen/pre_commit_hook",
-        "Docs" => "http://tyrchen.github.io/pre_commit_hook/"
+        "GitHub" => "https://github.com/tyrchen/ex_pre_commit_hook"
       }
     ]
   end


### PR DESCRIPTION
the Docs link was not resolving, and the github link was missing the `ex_` in the project